### PR TITLE
Authenticate BVBRCUtils session so private BV-BRC genomes are reachable

### DIFF
--- a/src/kbutillib/bvbrc_utils.py
+++ b/src/kbutillib/bvbrc_utils.py
@@ -45,6 +45,23 @@ class BVBRCUtils(KBGenomeUtils,KBAnnotationUtils):
         self.session = requests.Session()
         self.session.verify = verify_ssl
 
+        # Authenticate against BV-BRC API when a PATRIC token is available.
+        # Without this header, queries only see public genomes, so users
+        # cannot fetch private genomes they own (e.g. RASTtk-annotated ones)
+        # for downstream model reconstruction. The token is set as a session
+        # default so all `self.session.get(...)` calls in this module
+        # (fetch_genome_metadata, fetch_genome_sequences, fetch_genome_features,
+        # fetch_feature_sequences) include it. Falls back silently to
+        # unauthenticated mode if no token is configured (public-only behavior
+        # is preserved).
+        try:
+            patric_token = self.get_token(namespace="patric")
+            if patric_token:
+                self.session.headers["Authorization"] = patric_token
+        except Exception:
+            # Tolerate any token-lookup failure; leave session unauthenticated.
+            pass
+
         # Suppress SSL warnings if not verifying
         if not verify_ssl:
             import urllib3


### PR DESCRIPTION
## Problem

`BVBRCUtils` maintains a `requests.Session` for all calls into the BV-BRC API but never attaches an `Authorization` header. Even when callers pass `token={\"patric\": \"...\"}` into the constructor (the standard pattern used elsewhere in this library, e.g. `patric_ws_utils.py`), the session goes out unauthenticated.

As a result, `fetch_genome_metadata()` and the sibling `fetch_*()` methods only see **public** genomes. Private genomes the user owns (e.g. RASTtk-annotated ones in their BV-BRC workspace) return `[]` from the API and bubble up as `ValueError(\"No genome found with ID ...\")` from line 74.

## Reproducer

```python
from kbutillib import BVBRCUtils

# A private genome owned by my PATRIC user (BVBRC API confirms it exists when I curl with my token):
b = BVBRCUtils(token={\"patric\": MY_PATRIC_TOKEN, \"kbase\": \"unused\"}, ...)
b.fetch_genome_metadata(\"511145.795\")
# raises: ValueError: No genome found with ID 511145.795
```

Direct verification that the genome is reachable when the request IS authenticated:
- `curl 'https://www.bv-brc.org/api/genome/?eq(genome_id,511145.795)&...'` → `[]`
- `curl -H 'Authorization: <patric>' 'https://www.bv-brc.org/api/genome/?eq(genome_id,511145.795)&...'` → returns the full metadata (4357 CDSs, owner=jplfaria@patricbrc.org)

## Fix

In `BVBRCUtils.__init__`, pull `self.get_token(namespace=\"patric\")` (the same mechanism `patric_ws_utils.py:283` already uses) and attach it as a default `Authorization` header on the session, if present. Wrapped in a try/except so deployments without a PATRIC token configured continue to work in public-only mode unchanged.

```python
try:
    patric_token = self.get_token(namespace=\"patric\")
    if patric_token:
        self.session.headers[\"Authorization\"] = patric_token
except Exception:
    pass
```

The auth then flows through automatically to all four `self.session.get(...)` calls in this module:
- `fetch_genome_metadata` (line 69)
- `fetch_genome_sequences` (line 90)
- `fetch_genome_features` (line 112)
- `fetch_feature_sequences` (line ~150)

## Verification

End-to-end against the live BV-BRC API:
- **Without** token: `fetch_genome_metadata(\"511145.795\")` raises `ValueError(\"No genome found with ID 511145.795\")` (the original bug)
- **With** token: returns `{\"genome_name\": \"Escherichia coli str. K-12 substr. MG1655\", \"owner\": \"jplfaria@patricbrc.org\", \"patric_cds\": 4357, ...}`

Backwards-compat: deployments that don't pass a token still get the existing public-only behavior (no header added → BV-BRC returns public genomes only).

## Context

Discovered while wiring up an external project's \"Build Model from RAST job\" workflow against ModelSEED reconstruction. With this fix, users can run reconstruction directly against their **private** RASTtk-annotated BV-BRC genomes (4 of mine, dating from 2015 to 2020, are unreachable today). It also opens the path for any downstream tool to access user-owned genomes via the modern PATRIC token flow rather than depending on the legacy RAST server / MSSeedSupportServer for that data.