### PR TITLE
Guard against None solutions in gapfill_metabolic_model

### DIFF
--- a/src/kbutillib/ms_reconstruction_utils.py
+++ b/src/kbutillib/ms_reconstruction_utils.py
@@ -790,6 +790,12 @@ class MSReconstructionUtils(KBModelUtils):
 
         output_solution = None
         output_solution_media = None
+        # `run_multi_gapfill` returns None when no gapfill solution exists
+        # (e.g. solver infeasible, model+media combination cannot grow). Guard
+        # before treating `solutions` as a dict; otherwise `media in solutions`
+        # raises TypeError.
+        if solutions is None:
+            solutions = {}
         for media in media_objs:
             if media in solutions and "growth" in solutions[media]:
                 growth_array.append(media.id + ":" + str(solutions[media]["growth"]))


### PR DESCRIPTION
## Summary

One-line guard for a TypeError that surfaces when \`run_multi_gapfill\` finds no viable gapfill solution.

## The bug

\`MSReconstructionUtils.gapfill_metabolic_model\` does:

\`\`\`python
solutions = msgapfill.run_multi_gapfill(...)   # returns None when no solution exists
...
for media in media_objs:
    if media in solutions and "growth" in solutions[media]:   # TypeError: argument of type 'NoneType' is not iterable
\`\`\`

When the inner solver returns no solutions (e.g. solver infeasible, or model + media combination cannot grow), \`solutions\` is \`None\`, not \`{}\`. The membership check then raises \`TypeError\` instead of letting the no-solution case fall through naturally.

## Reproducer

Caught downstream in modelseed-api's gapfill task:

1. Build a model with reconstruct \`gapfill=False\` (so no exchanges/transports added)
2. Call standalone gapfill on it with a glucose-only minimal media (\`Carbon-D-Glucose\`)
3. Solver finds no growth (model has no transports for glucose), returns \`None\`
4. \`TypeError: argument of type 'NoneType' is not iterable\` instead of a clean \"no viable gapfill solution\" outcome

Worker traceback:

\`\`\`
File \"/app/src/modelseed_api/jobs/tasks.py\", line 790, in gapfill
    gf_output, solutions, _, _ = recon.gapfill_metabolic_model(...)
File \"/deps/KBUtilLib/src/kbutillib/ms_reconstruction_utils.py\", line 794, in gapfill_metabolic_model
    if media in solutions and \"growth\" in solutions[media]:
TypeError: argument of type 'NoneType' is not iterable
\`\`\`

## The fix

Coerce \`None\` to \`{}\` before the membership check. The downstream \`growth_array\` stays empty, the no-solution case falls through naturally to the rest of the function, and \`output_solution\` remains \`None\`. Behavior on the success path (non-None solutions dict) is unchanged.

## Why it doesn't surface in the typical website flow

The public modelseed.org flow uses the combined reconstruct + gapfill path with Complete media (the \"all exchanges open\" sentinel), which always finds a viable growth solution. This bug only surfaces on standalone gapfill calls against incomplete models or genuinely infeasible model+media combinations. Surfacing it as a clean no-solution result rather than a TypeError makes infeasibility actionable for the caller.

## Test plan

- [x] Local edit verified (single-line guard, no behavior change for success path)
- [ ] Once merged: redeploy on modelseed-api, rerun the failing standalone gapfill, confirm clean no-solution outcome rather than TypeError