### PR TITLE
Predictive thermodynamics: pluggable dG'/dGf backends (equilibrator, dGPredictor, ModelSEED-DB)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,22 @@ dependencies = [
 ]
 
 
+[project.optional-dependencies]
+# Optional thermodynamics predictor backends. The predictive_thermo facade
+# degrades gracefully when these are absent, so they are not core deps.
+# equilibrator-api is MIT-licensed (Beber et al., GitLab/equilibrator).
+equilibrator = [
+  "equilibrator-api >=0.6.0",
+]
+# Umbrella for all currently pip-installable thermo backends. dGPredictor and
+# molGPK are research code with custom installs (local clone / unreleased) and
+# are intentionally NOT listed here; the facade detects and uses them at runtime
+# when configured, and degrades gracefully when they are absent.
+thermo = [
+  "equilibrator-api >=0.6.0",
+]
+
+
 [project.urls]
 Homepage = "https://github.com/cshenry/KBUtilLib"
 Repository = "https://github.com/cshenry/KBUtilLib"

--- a/src/kbutillib/__init__.py
+++ b/src/kbutillib/__init__.py
@@ -129,6 +129,12 @@ except ImportError as e:
     ThermoUtils = None
 
 try:
+    from .predictive_thermo_utils import PredictiveThermoUtils
+except ImportError as e:
+    _import_error("predictive_thermo_utils", e)
+    PredictiveThermoUtils = None
+
+try:
     from .kb_reads_utils import KBReadsUtils, Assembly, AssemblySet, Reads, ReadSet
 except ImportError as e:
     _import_error("kb_reads_utils", e)
@@ -287,6 +293,11 @@ except ImportError:
     ThermoUtilsImpl = None
 
 try:
+    from .predictive_thermo_utils import PredictiveThermoUtilsImpl
+except ImportError:
+    PredictiveThermoUtilsImpl = None
+
+try:
     from .mmseqs_utils import MMSeqsUtilsImpl
 except ImportError:
     MMSeqsUtilsImpl = None
@@ -371,6 +382,7 @@ __all__ = [
     "ReadSet",
     "SKANIUtils",
     "ThermoUtils",
+    "PredictiveThermoUtils",
     # Composition-based Impl classes
     "AICurationUtilsImpl",
     "ArgoUtilsImpl",
@@ -395,6 +407,7 @@ __all__ = [
     "RCSBPDBUtilsImpl",
     "SKANIUtilsImpl",
     "ThermoUtilsImpl",
+    "PredictiveThermoUtilsImpl",
     # Endpoints
     "base_url",
     "env_from_url",

--- a/src/kbutillib/predictive_thermo_utils.py
+++ b/src/kbutillib/predictive_thermo_utils.py
@@ -1,0 +1,389 @@
+"""Unified predictive-thermodynamics facade with backend dispatch.
+
+:class:`PredictiveThermoUtils` is the single entry point for estimating
+reaction transformed Gibbs free energies (and, where supported, compound
+formation energies and pKa / microspecies properties) across several backends:
+
+* ``equilibrator`` — real component-contribution predictor (optional dep).
+* ``modelseed_db`` — baked eQuilibrator deltaG from Andrew Freiburger's
+  ModelSEED Database fork (~10.6k compounds / ~43k reactions, EQU-tagged;
+  read directly from the TSVs, no dependency). Preferred within the ModelSEED
+  biochemistry universe.
+* ``modelseed``    — ModelSEED-DB lookups via the existing ThermoUtils (always
+  available; no new dependency).
+* ``dgpredictor``  — Maranas-lab reaction ΔG predictor (stub until integrated).
+* ``molgpk``       — pKa / microspecies predictor (stub until integrated).
+
+Dispatch model
+--------------
+* ``backend="name"`` targets a single backend explicitly.
+* ``backend=None`` (default) walks a priority order and returns the first
+  backend that produces a numeric estimate, recording in ``warnings`` which
+  backends were skipped/failed. The default order favors the rigorous
+  predictor when present and falls back to database lookups:
+  ``equilibrator -> dgpredictor -> modelseed``.
+
+Nothing here ever fabricates a thermodynamic value: if no backend can produce
+one, the returned estimate has ``dg_prime is None`` / ``dgf is None`` with
+explanatory warnings.
+
+This module follows KBUtilLib's composition convention: the
+:class:`PredictiveThermoUtils` class is for standalone use, while
+:class:`PredictiveThermoUtilsImpl` is the composition wrapper registered on the
+:class:`kbutillib.toolkit.KBUtilLib` toolkit.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from .shared_env_utils import SharedEnvUtils
+from .thermo_predictors import (
+    CompoundThermoEstimate,
+    DGPredictorBackend,
+    EquilibratorBackend,
+    ModelSEEDBackend,
+    ModelSEEDDBBackend,
+    MolGPKBackend,
+    ReactionThermoEstimate,
+)
+from .thermo_predictors.base import BackendUnavailableError
+
+#: Default priority order for reaction ΔG'° dispatch.
+DEFAULT_REACTION_ORDER: Sequence[str] = (
+    "equilibrator",
+    "dgpredictor",
+    "modelseed_db",
+    "modelseed",
+)
+#: Default priority order for compound ΔGf dispatch.
+DEFAULT_COMPOUND_ORDER: Sequence[str] = (
+    "equilibrator",
+    "modelseed_db",
+    "modelseed",
+)
+
+
+class PredictiveThermoUtils(SharedEnvUtils):
+    """Backend-dispatching predictive thermodynamics utilities.
+
+    Args:
+        thermo_utils: Optional :class:`kbutillib.thermo_utils.ThermoUtils` (or
+            ``ThermoUtilsImpl``) used by the ModelSEED backend. If ``None``, a
+            ``ThermoUtils`` is lazily constructed when first needed.
+        **kwargs: Passed to :class:`SharedEnvUtils`.
+    """
+
+    def __init__(self, thermo_utils: Any = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._thermo_utils = thermo_utils
+        self._backends: Optional[Dict[str, Any]] = None
+
+    # ── backend wiring ──────────────────────────────────────────────────
+
+    @property
+    def thermo_utils(self) -> Any:
+        """Lazily build a ThermoUtils for the ModelSEED backend if needed."""
+        if self._thermo_utils is None:
+            from .thermo_utils import ThermoUtils
+
+            self._thermo_utils = ThermoUtils(
+                config_file=False, token_file=None, kbase_token_file=None
+            )
+        return self._thermo_utils
+
+    def _build_backends(self) -> Dict[str, Any]:
+        """Instantiate all backends (cheap; heavy deps stay deferred)."""
+        return {
+            "equilibrator": EquilibratorBackend(logger=self),
+            "dgpredictor": DGPredictorBackend(
+                config_resolver=self.get_config_value, logger=self
+            ),
+            "molgpk": MolGPKBackend(
+                config_resolver=self.get_config_value, logger=self
+            ),
+            "modelseed_db": ModelSEEDDBBackend(
+                config_resolver=self.get_config_value, logger=self
+            ),
+            "modelseed": ModelSEEDBackend(self.thermo_utils, logger=self),
+        }
+
+    @property
+    def backends(self) -> Dict[str, Any]:
+        """Mapping of backend name -> backend instance (lazily built)."""
+        if self._backends is None:
+            self._backends = self._build_backends()
+        return self._backends
+
+    def get_backend(self, name: str) -> Any:
+        """Return a backend by name.
+
+        Args:
+            name: Backend identifier.
+
+        Returns:
+            The backend instance.
+
+        Raises:
+            KeyError: If no backend with that name is registered.
+        """
+        try:
+            return self.backends[name]
+        except KeyError:
+            raise KeyError(
+                f"Unknown thermo backend '{name}'. "
+                f"Available: {sorted(self.backends)}"
+            )
+
+    def backend_status(self) -> Dict[str, Dict[str, Any]]:
+        """Return availability + capabilities for every backend.
+
+        Useful for diagnostics and for tests that assert graceful degradation.
+
+        Returns:
+            ``{name: {"available": bool, "reason": str|None,
+            "capabilities": [str, ...]}}``.
+        """
+        status: Dict[str, Dict[str, Any]] = {}
+        for name, backend in self.backends.items():
+            status[name] = {
+                "available": bool(backend.available),
+                "reason": backend.unavailable_reason,
+                "capabilities": sorted(backend.capabilities),
+            }
+        return status
+
+    def _resolve_order(
+        self, backend: Optional[str], default: Sequence[str]
+    ) -> List[str]:
+        if backend is not None:
+            return [backend]
+        return list(default)
+
+    # ── reaction ────────────────────────────────────────────────────────
+
+    def reaction_dg_prime(
+        self,
+        reaction_id: str,
+        stoichiometry: Optional[Mapping[str, float]] = None,
+        backend: Optional[str] = None,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        p_mg: float = 14.0,
+        **kwargs: Any,
+    ) -> ReactionThermoEstimate:
+        """Estimate a reaction's standard transformed Gibbs free energy.
+
+        Args:
+            reaction_id: Reaction identifier. For the ModelSEED backend this is
+                a ``rxnNNNNN`` accession; for equilibrator the ``stoichiometry``
+                is used (namespaced compound ids) and this only labels the
+                result.
+            stoichiometry: Mapping of compound id -> signed coefficient. May be
+                ``None`` when targeting the ModelSEED backend (which resolves the
+                reaction by accession).
+            backend: Force a single backend by name, or ``None`` to walk the
+                default priority order.
+            ph, ionic_strength, temperature, p_mg: Physiological conditions.
+            **kwargs: Forwarded to the backend.
+
+        Returns:
+            A :class:`ReactionThermoEstimate`. If no backend produces a value,
+            ``dg_prime`` is ``None`` with warnings listing what was tried.
+        """
+        stoich = dict(stoichiometry or {})
+        order = self._resolve_order(backend, DEFAULT_REACTION_ORDER)
+        attempted_warnings: List[str] = []
+        last: Optional[ReactionThermoEstimate] = None
+
+        for name in order:
+            be = self.backends.get(name)
+            if be is None:
+                attempted_warnings.append(f"[{name}] not registered")
+                continue
+            if "reaction_dg" not in be.capabilities:
+                attempted_warnings.append(f"[{name}] does not provide reaction ΔG")
+                continue
+            if not be.available:
+                attempted_warnings.append(f"[{name}] unavailable: {be.unavailable_reason}")
+                continue
+            try:
+                est = be.reaction_dg_prime(
+                    reaction_id,
+                    stoich,
+                    ph=ph,
+                    ionic_strength=ionic_strength,
+                    temperature=temperature,
+                    p_mg=p_mg,
+                    **kwargs,
+                )
+            except BackendUnavailableError as exc:
+                attempted_warnings.append(f"[{name}] unavailable: {exc}")
+                continue
+            except Exception as exc:  # defensive: never let one backend break dispatch
+                attempted_warnings.append(f"[{name}] errored: {type(exc).__name__}: {exc}")
+                continue
+            last = est
+            if est.is_estimated:
+                if backend is None and len(order) > 1:
+                    est.warnings.insert(0, f"estimated by backend '{name}'")
+                return est
+            attempted_warnings.append(
+                f"[{name}] produced no value"
+                + (f": {est.warnings[-1]}" if est.warnings else "")
+            )
+
+        # No backend produced a numeric value: return an empty-but-honest result.
+        result = last or ReactionThermoEstimate(
+            reaction_id=reaction_id,
+            backend=order[0] if order else "none",
+            ph=ph,
+            ionic_strength=ionic_strength,
+            temperature=temperature,
+            p_mg=p_mg,
+        )
+        result.warnings.extend(attempted_warnings)
+        return result
+
+    # ── compound ────────────────────────────────────────────────────────
+
+    def compound_dgf(
+        self,
+        compound_id: str,
+        backend: Optional[str] = None,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        """Estimate a compound's standard formation energy / microspecies.
+
+        Args:
+            compound_id: Compound identifier (namespace is backend-specific).
+            backend: Force a single backend, or ``None`` for priority order.
+            ph, ionic_strength, temperature: Conditions.
+            **kwargs: Forwarded to the backend.
+
+        Returns:
+            A :class:`CompoundThermoEstimate`. ``dgf`` is ``None`` (with
+            warnings) if no backend produced a value.
+        """
+        order = self._resolve_order(backend, DEFAULT_COMPOUND_ORDER)
+        attempted_warnings: List[str] = []
+        last: Optional[CompoundThermoEstimate] = None
+
+        for name in order:
+            be = self.backends.get(name)
+            if be is None:
+                attempted_warnings.append(f"[{name}] not registered")
+                continue
+            if "compound_dgf" not in be.capabilities:
+                attempted_warnings.append(f"[{name}] does not provide compound ΔGf")
+                continue
+            if not be.available:
+                attempted_warnings.append(f"[{name}] unavailable: {be.unavailable_reason}")
+                continue
+            try:
+                est = be.compound_dgf(
+                    compound_id,
+                    ph=ph,
+                    ionic_strength=ionic_strength,
+                    temperature=temperature,
+                    **kwargs,
+                )
+            except BackendUnavailableError as exc:
+                attempted_warnings.append(f"[{name}] unavailable: {exc}")
+                continue
+            except Exception as exc:
+                attempted_warnings.append(f"[{name}] errored: {type(exc).__name__}: {exc}")
+                continue
+            last = est
+            if est.dgf is not None:
+                if backend is None and len(order) > 1:
+                    est.warnings.insert(0, f"estimated by backend '{name}'")
+                return est
+            attempted_warnings.append(
+                f"[{name}] produced no value"
+                + (f": {est.warnings[-1]}" if est.warnings else "")
+            )
+
+        result = last or CompoundThermoEstimate(
+            compound_id=compound_id,
+            backend=order[0] if order else "none",
+            ph=ph,
+            ionic_strength=ionic_strength,
+            temperature=temperature,
+        )
+        result.warnings.extend(attempted_warnings)
+        return result
+
+    # ── microspecies / pKa (molgpk only) ────────────────────────────────
+
+    def compound_microspecies(
+        self,
+        compound_id: str,
+        ph: float = 7.0,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        """Estimate pKa values and the major microspecies for a compound.
+
+        Routed exclusively to the ``molgpk`` backend (stub until integrated).
+
+        Args:
+            compound_id: Compound identifier accepted by molGPK.
+            ph: pH at which to report the predominant microspecies.
+            **kwargs: Forwarded to the backend.
+
+        Returns:
+            A :class:`CompoundThermoEstimate`. If molGPK is not configured, the
+            result carries a warning and empty ``pka_values`` (no fabrication).
+        """
+        be = self.get_backend("molgpk")
+        est = CompoundThermoEstimate(compound_id=compound_id, backend="molgpk", ph=ph)
+        if not be.available:
+            est.warnings.append(f"[molgpk] unavailable: {be.unavailable_reason}")
+            return est
+        try:
+            return be.compound_dgf(compound_id, ph=ph, **kwargs)
+        except BackendUnavailableError as exc:
+            est.warnings.append(f"[molgpk] unavailable: {exc}")
+            return est
+
+
+class PredictiveThermoUtilsImpl:
+    """Composition wrapper for :class:`PredictiveThermoUtils`.
+
+    Holds ``env`` and a ``thermo`` delegate instead of inheriting from
+    :class:`SharedEnvUtils`, matching the pattern used by
+    :class:`kbutillib.thermo_utils.ThermoUtilsImpl`. Delegates all other
+    attribute access to an internal :class:`PredictiveThermoUtils` instance.
+
+    Args:
+        env: A :class:`SharedEnvUtils` instance.
+        thermo: The toolkit's existing ThermoUtils(Impl) instance, reused for
+            the ModelSEED backend.
+        **kwargs: Forwarded to the internal ``PredictiveThermoUtils``.
+    """
+
+    def __init__(self, env: Any, thermo: Any, **kwargs: Any) -> None:
+        self._env = env
+        self._thermo = thermo
+        _kwargs = {
+            "config_file": False,
+            "token_file": None,
+            "kbase_token_file": None,
+        }
+        _kwargs.update(kwargs)
+        self._delegate = PredictiveThermoUtils(thermo_utils=thermo, **_kwargs)
+
+    @property
+    def env(self) -> Any:
+        return self._env
+
+    @property
+    def thermo(self) -> Any:
+        return self._thermo
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._delegate, name)

--- a/src/kbutillib/thermo_predictors/__init__.py
+++ b/src/kbutillib/thermo_predictors/__init__.py
@@ -1,0 +1,66 @@
+"""Predictive thermodynamics backends for KBUtilLib.
+
+This subpackage provides a pluggable set of backends that estimate standard
+transformed Gibbs free energies of reaction (and, where supported, compound
+formation energies and pKa / microspecies properties) from chemical structure
+or identifier.
+
+Design
+------
+The existing :class:`kbutillib.thermo_utils.ThermoUtils` performs ModelSEED
+database lookups and ion-transfer accounting. It does *not* predict
+thermodynamic values for compounds/reactions that are absent from the
+ModelSEED database. This subpackage layers prediction on top of that
+foundation without changing existing behavior:
+
+* Each backend implements :class:`ThermoBackend` (a structural protocol).
+* Backends are *optional*: a backend that cannot import its dependency, or
+  whose external tool is not configured, reports ``available == False`` and a
+  human-readable ``unavailable_reason`` instead of raising at import time.
+* :class:`kbutillib.predictive_thermo_utils.PredictiveThermoUtils` dispatches
+  to backends by name or by a priority order, and degrades gracefully.
+
+Backends
+--------
+``equilibrator``
+    Real, MIT-licensed component-contribution predictor
+    (``equilibrator-api``). Wired and validated.
+``modelseed``
+    Adapter over the existing :class:`ThermoUtils` ModelSEED-DB lookups; serves
+    as the always-on fallback (no new dependency).
+``dgpredictor``
+    Maranas/Tyo-lab group-contribution reaction predictor (Andrew Freiburger's
+    fork). Runs out-of-process against a local clone; reports
+    ``available == False`` until the repo + trained model are configured.
+``molgpk``
+    Tyo-lab microscopic-pKa / formation-energy predictor (molGPK / OPAM2).
+    Interface is stubbed pending its public release; reports
+    ``available == False`` until configured. It never fabricates values.
+
+Nothing in this subpackage imports a heavy/optional dependency at module import
+time; all such imports are deferred into the backend that needs them.
+"""
+
+from .base import (
+    BackendUnavailableError,
+    CompoundThermoEstimate,
+    ReactionThermoEstimate,
+    ThermoBackend,
+)
+from .dgpredictor_backend import DGPredictorBackend
+from .equilibrator_backend import EquilibratorBackend
+from .modelseed_backend import ModelSEEDBackend
+from .modelseed_db_backend import ModelSEEDDBBackend
+from .molgpk_backend import MolGPKBackend
+
+__all__ = [
+    "BackendUnavailableError",
+    "CompoundThermoEstimate",
+    "ReactionThermoEstimate",
+    "ThermoBackend",
+    "DGPredictorBackend",
+    "EquilibratorBackend",
+    "ModelSEEDBackend",
+    "ModelSEEDDBBackend",
+    "MolGPKBackend",
+]

--- a/src/kbutillib/thermo_predictors/base.py
+++ b/src/kbutillib/thermo_predictors/base.py
@@ -1,0 +1,201 @@
+"""Backend protocol and result types for predictive thermodynamics.
+
+These definitions deliberately depend only on the Python standard library so
+that importing :mod:`kbutillib.thermo_predictors` never pulls in a heavy or
+optional scientific dependency. Concrete backends import their dependencies
+lazily inside their own modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Protocol, runtime_checkable
+
+
+class BackendUnavailableError(RuntimeError):
+    """Raised when a thermodynamic backend is asked to compute a value but its
+    dependency or external tool is not installed/configured.
+
+    Callers that prefer graceful degradation should check
+    :attr:`ThermoBackend.available` first, or use
+    :class:`kbutillib.predictive_thermo_utils.PredictiveThermoUtils`, which
+    catches this and tries the next backend.
+    """
+
+
+# Sentinel used throughout to flag "value genuinely not known" as distinct from
+# a numeric zero. Backends must never substitute a fabricated number for an
+# unknown value.
+UNKNOWN: None = None
+
+
+@dataclass
+class CompoundThermoEstimate:
+    """A backend's estimate of a compound's formation thermodynamics.
+
+    All energies are in kJ/mol. ``None`` means "not estimated by this backend";
+    it is never a stand-in for a real value.
+    """
+
+    compound_id: str
+    backend: str
+    dgf: Optional[float] = None
+    dgf_uncertainty: Optional[float] = None
+    pka_values: List[float] = field(default_factory=list)
+    major_microspecies: Optional[str] = None
+    ph: Optional[float] = None
+    ionic_strength: Optional[float] = None
+    temperature: Optional[float] = None
+    warnings: List[str] = field(default_factory=list)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a plain JSON-serializable dict representation."""
+        return {
+            "compound_id": self.compound_id,
+            "backend": self.backend,
+            "dgf": self.dgf,
+            "dgf_uncertainty": self.dgf_uncertainty,
+            "pka_values": list(self.pka_values),
+            "major_microspecies": self.major_microspecies,
+            "ph": self.ph,
+            "ionic_strength": self.ionic_strength,
+            "temperature": self.temperature,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass
+class ReactionThermoEstimate:
+    """A backend's estimate of a reaction's transformed Gibbs free energy.
+
+    ``dg_prime`` is the standard transformed Gibbs energy of reaction
+    (delta_r G'^0) at the given conditions, in kJ/mol. ``None`` means the
+    backend could not estimate it (e.g. a participating compound was
+    unidentifiable); it is never a stand-in for a real value.
+    """
+
+    reaction_id: str
+    backend: str
+    dg_prime: Optional[float] = None
+    dg_prime_uncertainty: Optional[float] = None
+    ph: Optional[float] = None
+    ionic_strength: Optional[float] = None
+    temperature: Optional[float] = None
+    p_mg: Optional[float] = None
+    equation: Optional[str] = None
+    missing_compounds: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_estimated(self) -> bool:
+        """True if a numeric free-energy value was produced."""
+        return self.dg_prime is not None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a plain JSON-serializable dict representation."""
+        return {
+            "reaction_id": self.reaction_id,
+            "backend": self.backend,
+            "dg_prime": self.dg_prime,
+            "dg_prime_uncertainty": self.dg_prime_uncertainty,
+            "ph": self.ph,
+            "ionic_strength": self.ionic_strength,
+            "temperature": self.temperature,
+            "p_mg": self.p_mg,
+            "equation": self.equation,
+            "missing_compounds": list(self.missing_compounds),
+            "warnings": list(self.warnings),
+        }
+
+
+@runtime_checkable
+class ThermoBackend(Protocol):
+    """Structural interface every predictive-thermodynamics backend implements.
+
+    A backend is *optional*. Construction must never raise merely because the
+    backend's dependency is missing; instead the backend reports
+    :attr:`available` as ``False`` and explains via :attr:`unavailable_reason`.
+    Compute methods raise :class:`BackendUnavailableError` if called while
+    unavailable.
+    """
+
+    #: Short stable identifier, e.g. ``"equilibrator"``.
+    name: str
+
+    @property
+    def available(self) -> bool:
+        """Whether this backend can currently perform computations."""
+        ...
+
+    @property
+    def unavailable_reason(self) -> Optional[str]:
+        """Human-readable explanation when :attr:`available` is ``False``."""
+        ...
+
+    @property
+    def capabilities(self) -> "frozenset[str]":
+        """Set of capability tags this backend supports.
+
+        Recognized tags: ``"reaction_dg"``, ``"compound_dgf"``, ``"pka"``,
+        ``"major_microspecies"``.
+        """
+        ...
+
+    def reaction_dg_prime(
+        self,
+        reaction_id: str,
+        stoichiometry: Mapping[str, float],
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        p_mg: float = 14.0,
+        **kwargs: Any,
+    ) -> ReactionThermoEstimate:
+        """Estimate standard transformed Gibbs energy of a reaction.
+
+        Args:
+            reaction_id: Identifier used only for labeling the result.
+            stoichiometry: Mapping of compound identifier -> signed coefficient
+                (negative for substrates, positive for products). The identifier
+                namespace a backend accepts is backend-specific (e.g. ModelSEED
+                ``cpdNNNNN``, KEGG ``CNNNNN``, InChI, or SMILES).
+            ph: Reaction pH.
+            ionic_strength: Ionic strength in M.
+            temperature: Temperature in K.
+            p_mg: pMg (negative log of free Mg2+ activity).
+            **kwargs: Backend-specific options.
+
+        Returns:
+            A :class:`ReactionThermoEstimate`.
+
+        Raises:
+            BackendUnavailableError: If the backend is not available.
+        """
+        ...
+
+    def compound_dgf(
+        self,
+        compound_id: str,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        """Estimate a compound's transformed formation energy / microspecies.
+
+        Args:
+            compound_id: Compound identifier (namespace is backend-specific).
+            ph: pH.
+            ionic_strength: Ionic strength in M.
+            temperature: Temperature in K.
+            **kwargs: Backend-specific options.
+
+        Returns:
+            A :class:`CompoundThermoEstimate`.
+
+        Raises:
+            BackendUnavailableError: If the backend is not available.
+        """
+        ...

--- a/src/kbutillib/thermo_predictors/dgpredictor_backend.py
+++ b/src/kbutillib/thermo_predictors/dgpredictor_backend.py
@@ -1,0 +1,321 @@
+"""dGPredictor backend — reaction ΔG'° via the Maranas/Tyo-lab predictor.
+
+dGPredictor (Wang et al., Maranas lab; the fork used here is Andrew Freiburger's
+``freiburgermsu/dGPredictor`` at ``master``) predicts the standard transformed
+Gibbs free energy of reaction (delta_r G'^0) from molecular-substructure
+("group") features using a Bayesian-ridge model trained on TECRDB.
+
+Why a subprocess
+----------------
+dGPredictor is research code with a heavy and fragile runtime: it imports
+``rdkit`` and ``openbabel`` at module top, ships its own copy of the
+component-contribution package under ``CC/`` that uses *bare* imports
+(``from compound import ...``) and therefore only works with ``CC/`` on
+``sys.path`` and the **current working directory set to the repo root**, and it
+loads a ~150 MB joblib model plus several MB of group-signature JSON. Importing
+all of that into the KBUtilLib process would pollute ``sys.path``/cwd and pin
+those heavy deps onto every consumer.
+
+Instead this backend shells out to a small worker script
+(``kbutillib_dg_worker.py``) placed in the dGPredictor repo. The worker sets up
+cwd/sys.path correctly, loads the model once per call, and answers a single
+reaction over a JSON stdin/stdout protocol. KBUtilLib never imports dGPredictor
+or its dependencies.
+
+Identifiers, units, conditions
+------------------------------
+* Input ``stoichiometry`` is a mapping of **KEGG compound IDs** (e.g.
+  ``"C00002"``) to signed coefficients (negative = substrate). This is the only
+  namespace dGPredictor's group-decomposition tables understand.
+* Output is **delta_r G'^0 in kJ/mol** with the model's posterior standard
+  deviation as the uncertainty (the value already includes the Legendre
+  transform to the requested pH / ionic strength via the bundled compound
+  cache).
+* Temperature is fixed at 298.15 K inside dGPredictor and cannot be varied;
+  ``temperature`` and ``p_mg`` arguments are accepted but **ignored**, and a
+  warning is attached when they deviate from the supported values.
+
+Configuration
+-------------
+Resolved (in order) from explicit args, the config resolver, then environment:
+
+* repo path:   ``thermo.dgpredictor.repo_path``  / ``DGPREDICTOR_REPO``
+* python exe:  ``thermo.dgpredictor.python``      / ``DGPREDICTOR_PYTHON``
+  (defaults to the interpreter running KBUtilLib; must have rdkit + openbabel)
+
+If the repo / worker / model artifact cannot be found, the backend reports
+``available == False`` with a precise reason and never fabricates a value. In
+particular it detects the common failure where ``model/M12_model_BR.pkl`` is an
+unpulled Git LFS pointer (a few dozen bytes) rather than the real model.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Mapping, Optional
+
+from .base import (
+    BackendUnavailableError,
+    CompoundThermoEstimate,
+    ReactionThermoEstimate,
+)
+
+#: Config keys (dot-notation).
+CONFIG_REPO_PATH = "thermo.dgpredictor.repo_path"
+CONFIG_PYTHON = "thermo.dgpredictor.python"
+
+#: Environment fallbacks.
+ENV_REPO_PATH = "DGPREDICTOR_REPO"
+ENV_PYTHON = "DGPREDICTOR_PYTHON"
+
+#: Worker script name (placed in the dGPredictor repo by the integration).
+WORKER_SCRIPT = "kbutillib_dg_worker.py"
+
+#: Smallest plausible size (bytes) of the real joblib model; below this the
+#: file is almost certainly an unpulled Git LFS pointer.
+_MIN_MODEL_BYTES = 1_000_000
+
+#: dGPredictor's fixed temperature (K).
+_FIXED_TEMPERATURE = 298.15
+
+#: Per-call subprocess timeout (s): model load dominates first call.
+_TIMEOUT_S = 600
+
+
+def _not_configured() -> str:
+    return (
+        "dGPredictor backend is not configured. Set the repo path via the "
+        f"`{CONFIG_REPO_PATH}` config key or the `{ENV_REPO_PATH}` environment "
+        "variable (clone freiburgermsu/dGPredictor and ensure the joblib model "
+        "model/M12_model_BR.pkl is present — run model_gen.py if it is an "
+        "unpulled Git LFS pointer). The interpreter used to run it needs rdkit "
+        "and openbabel installed."
+    )
+
+
+class DGPredictorBackend:
+    """dGPredictor reaction ΔG'° predictor (subprocess-isolated).
+
+    Args:
+        repo_path: Path to the dGPredictor repo. If omitted, resolved from
+            config / environment.
+        python_exe: Interpreter used to run the worker (needs rdkit + openbabel).
+            Defaults to the current interpreter.
+        config_resolver: Optional callable ``(key, default) -> value``.
+        logger: Optional logger.
+    """
+
+    name = "dgpredictor"
+
+    def __init__(
+        self,
+        repo_path: Optional[str] = None,
+        python_exe: Optional[str] = None,
+        config_resolver: Any = None,
+        logger: Any = None,
+    ) -> None:
+        self._config = config_resolver
+        self._logger = logger
+        self._explicit_repo = repo_path
+        self._explicit_python = python_exe
+        self._repo: Optional[str] = None
+        self._python: Optional[str] = None
+        self._worker: Optional[str] = None
+        self._unavailable_reason: Optional[str] = None
+        self._probed = False
+
+    # -- resolution ----------------------------------------------------------
+
+    def _cfg(self, key: str) -> Optional[str]:
+        if self._config is None:
+            return None
+        try:
+            val = self._config(key, None)
+        except Exception:  # pragma: no cover - resolver is best-effort
+            return None
+        return str(val) if val else None
+
+    def _probe(self) -> None:
+        if self._probed:
+            return
+        self._probed = True
+
+        repo = (
+            self._explicit_repo
+            or self._cfg(CONFIG_REPO_PATH)
+            or os.environ.get(ENV_REPO_PATH)
+        )
+        if not repo:
+            self._unavailable_reason = _not_configured()
+            return
+        repo = os.path.abspath(os.path.expanduser(repo))
+        if not os.path.isdir(repo):
+            self._unavailable_reason = f"dGPredictor repo not found: {repo}"
+            return
+
+        worker = os.path.join(repo, WORKER_SCRIPT)
+        if not os.path.isfile(worker):
+            self._unavailable_reason = (
+                f"dGPredictor worker script missing: {worker}. It is shipped "
+                "with the KBUtilLib integration; copy it into the repo."
+            )
+            return
+
+        model = os.path.join(repo, "model", "M12_model_BR.pkl")
+        if not os.path.isfile(model):
+            self._unavailable_reason = (
+                f"dGPredictor model artifact missing: {model}. Run model_gen.py "
+                "/ regen_model.py or `git lfs pull`."
+            )
+            return
+        if os.path.getsize(model) < _MIN_MODEL_BYTES:
+            self._unavailable_reason = (
+                f"dGPredictor model artifact at {model} is only "
+                f"{os.path.getsize(model)} bytes — this is an unpulled Git LFS "
+                "pointer, not the trained model. Run model_gen.py / "
+                "regen_model.py or `git lfs pull`."
+            )
+            return
+
+        python = (
+            self._explicit_python
+            or self._cfg(CONFIG_PYTHON)
+            or os.environ.get(ENV_PYTHON)
+            or sys.executable
+        )
+
+        self._repo = repo
+        self._worker = worker
+        self._python = python
+        self._unavailable_reason = None
+
+    @property
+    def available(self) -> bool:
+        self._probe()
+        return self._unavailable_reason is None
+
+    @property
+    def unavailable_reason(self) -> Optional[str]:
+        self._probe()
+        return self._unavailable_reason
+
+    @property
+    def capabilities(self) -> "frozenset[str]":
+        return frozenset({"reaction_dg"})
+
+    # -- compute -------------------------------------------------------------
+
+    def reaction_dg_prime(
+        self,
+        reaction_id: str,
+        stoichiometry: Mapping[str, float],
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        p_mg: float = 14.0,
+        **kwargs: Any,
+    ) -> ReactionThermoEstimate:
+        self._probe()
+        if self._unavailable_reason is not None:
+            raise BackendUnavailableError(self._unavailable_reason)
+
+        warnings = []
+        if abs(temperature - _FIXED_TEMPERATURE) > 1e-6:
+            warnings.append(
+                f"dGPredictor fixes T={_FIXED_TEMPERATURE} K; requested "
+                f"{temperature} K was ignored."
+            )
+
+        request = {
+            "rxn_dict": {str(k): float(v) for k, v in stoichiometry.items()},
+            "pH": float(ph),
+            "I": float(ionic_strength),
+            "rid": str(reaction_id),
+        }
+
+        try:
+            proc = subprocess.run(
+                [self._python, self._worker],  # type: ignore[list-item]
+                input=json.dumps(request),
+                capture_output=True,
+                text=True,
+                cwd=self._repo,
+                timeout=_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise BackendUnavailableError(
+                f"dGPredictor worker timed out after {_TIMEOUT_S}s"
+            ) from exc
+        except OSError as exc:
+            raise BackendUnavailableError(
+                f"could not launch dGPredictor worker: {exc}"
+            ) from exc
+
+        stdout = (proc.stdout or "").strip()
+        if not stdout:
+            raise BackendUnavailableError(
+                "dGPredictor worker produced no output; stderr: "
+                + (proc.stderr or "").strip()[-500:]
+            )
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise BackendUnavailableError(
+                f"dGPredictor worker returned non-JSON: {stdout[:300]} ({exc})"
+            ) from exc
+
+        if not payload.get("ok"):
+            # A per-reaction failure (e.g. an undecomposable compound) is not a
+            # backend-unavailable condition: return an unestimated result with
+            # the reason recorded, so dispatch can fall through to another
+            # backend without aborting.
+            warnings.append(
+                "dGPredictor could not estimate this reaction: "
+                + str(payload.get("error", "unknown error"))
+            )
+            return ReactionThermoEstimate(
+                reaction_id=reaction_id,
+                backend=self.name,
+                ph=ph,
+                ionic_strength=ionic_strength,
+                temperature=_FIXED_TEMPERATURE,
+                p_mg=None,
+                warnings=warnings,
+            )
+
+        return ReactionThermoEstimate(
+            reaction_id=reaction_id,
+            backend=self.name,
+            dg_prime=float(payload["dg_prime"]),
+            dg_prime_uncertainty=(
+                None
+                if payload.get("uncertainty") is None
+                else float(payload["uncertainty"])
+            ),
+            ph=float(payload.get("pH", ph)),
+            ionic_strength=float(payload.get("ionic_strength", ionic_strength)),
+            temperature=_FIXED_TEMPERATURE,
+            p_mg=None,
+            warnings=warnings,
+            raw={k: payload[k] for k in ("units", "transformed") if k in payload},
+        )
+
+    def compound_dgf(
+        self,
+        compound_id: str,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        """dGPredictor targets reactions, not standalone compound formation.
+
+        Raises:
+            BackendUnavailableError: Always (capability not provided).
+        """
+        raise BackendUnavailableError(
+            "dgpredictor does not provide standalone compound formation energies"
+        )

--- a/src/kbutillib/thermo_predictors/equilibrator_backend.py
+++ b/src/kbutillib/thermo_predictors/equilibrator_backend.py
@@ -1,0 +1,290 @@
+"""eQuilibrator component-contribution backend.
+
+Wraps the MIT-licensed ``equilibrator-api`` package
+(https://gitlab.com/equilibrator/equilibrator-api) to estimate standard
+transformed Gibbs free energies of reaction and compound formation from
+identifiers (KEGG, BiGG, MetaNetX, ChEBI), InChI, or InChIKey.
+
+The dependency is *optional*. Importing this module never imports
+``equilibrator_api``; the import is deferred until the backend is first used.
+If the package (or its ~1 GB local cache) is unavailable, the backend reports
+``available == False`` with an explanatory reason rather than raising.
+
+Identifier handling
+-------------------
+``equilibrator-api`` resolves compounds through accession namespaces using a
+``namespace:accession`` syntax (e.g. ``kegg:C00002``, ``bigg.metabolite:atp``,
+``metanetx.chemical:MNXM3``). This backend accepts identifiers that already
+carry such a prefix and passes them through. Plain ModelSEED ``cpdNNNNN`` IDs
+are *not* natively known to eQuilibrator; the umbrella dispatcher is
+responsible for translating those (via cross-references) before calling this
+backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from .base import (
+    BackendUnavailableError,
+    CompoundThermoEstimate,
+    ReactionThermoEstimate,
+)
+
+
+class EquilibratorBackend:
+    """Predict reaction/compound thermodynamics via eQuilibrator.
+
+    Args:
+        logger: Optional logger for diagnostics (duck-typed ``log_*`` / standard
+            ``logging.Logger`` both work; only ``warning``/``info`` are used and
+            calls are guarded).
+        component_contribution: Optional pre-built ``ComponentContribution``
+            instance (mainly for testing / dependency injection).
+    """
+
+    name = "equilibrator"
+
+    def __init__(
+        self,
+        logger: Any = None,
+        component_contribution: Any = None,
+    ) -> None:
+        self._logger = logger
+        self._cc = component_contribution
+        self._unavailable_reason: Optional[str] = None
+        self._probed = component_contribution is not None
+
+    # ── availability ────────────────────────────────────────────────────
+
+    def _log_warning(self, msg: str) -> None:
+        if self._logger is None:
+            return
+        warn = getattr(self._logger, "log_warning", None) or getattr(
+            self._logger, "warning", None
+        )
+        if callable(warn):
+            warn(msg)
+
+    def _probe(self) -> None:
+        """Lazily import equilibrator-api and build a ComponentContribution.
+
+        Sets ``self._cc`` on success or ``self._unavailable_reason`` on failure.
+        Safe to call repeatedly; only the first call does work.
+        """
+        if self._probed:
+            return
+        self._probed = True
+        try:
+            from equilibrator_api import ComponentContribution  # noqa: F401
+        except Exception as exc:  # ImportError or transitive import failure
+            self._unavailable_reason = (
+                "equilibrator-api is not installed "
+                f"({type(exc).__name__}: {exc}). Install with "
+                "`pip install equilibrator-api` (MIT licensed)."
+            )
+            self._log_warning(self._unavailable_reason)
+            return
+        try:
+            self._cc = ComponentContribution()
+        except Exception as exc:
+            # Typically a missing/corrupt local cache (~1 GB download on first
+            # use) or a network problem fetching it.
+            self._unavailable_reason = (
+                "equilibrator-api is installed but ComponentContribution() "
+                f"could not be constructed ({type(exc).__name__}: {exc}). "
+                "This usually means the local cache has not been downloaded yet."
+            )
+            self._log_warning(self._unavailable_reason)
+            self._cc = None
+
+    @property
+    def available(self) -> bool:
+        """Whether eQuilibrator is importable and a cache is ready."""
+        self._probe()
+        return self._cc is not None
+
+    @property
+    def unavailable_reason(self) -> Optional[str]:
+        """Why the backend is unavailable, or ``None`` if it is available."""
+        self._probe()
+        return self._unavailable_reason
+
+    @property
+    def capabilities(self) -> "frozenset[str]":
+        """Capabilities provided by this backend."""
+        return frozenset({"reaction_dg", "compound_dgf"})
+
+    def _require(self) -> Any:
+        if not self.available:
+            raise BackendUnavailableError(
+                self._unavailable_reason or "equilibrator backend unavailable"
+            )
+        return self._cc
+
+    # ── conditions ──────────────────────────────────────────────────────
+
+    def _apply_conditions(
+        self,
+        cc: Any,
+        ph: float,
+        ionic_strength: float,
+        temperature: float,
+        p_mg: float,
+    ) -> None:
+        """Set physiological conditions on the ComponentContribution object."""
+        from equilibrator_api import Q_
+
+        cc.p_h = Q_(ph)
+        cc.ionic_strength = Q_(f"{ionic_strength}M")
+        cc.temperature = Q_(f"{temperature}K")
+        cc.p_mg = Q_(p_mg)
+
+    @staticmethod
+    def _coeff_to_formula(stoichiometry: Mapping[str, float]) -> str:
+        """Render a stoichiometry mapping as an eQuilibrator reaction formula.
+
+        Substrates (negative coefficients) go on the left, products (positive)
+        on the right, e.g. ``kegg:C00002 + kegg:C00001 = kegg:C00008 +
+        kegg:C00009``.
+        """
+        left, right = [], []
+        for cid, coeff in stoichiometry.items():
+            if coeff == 0:
+                continue
+            mag = abs(coeff)
+            token = cid if mag == 1 else f"{mag} {cid}"
+            (left if coeff < 0 else right).append(token)
+        return f"{' + '.join(left)} = {' + '.join(right)}"
+
+    # ── reaction ────────────────────────────────────────────────────────
+
+    def reaction_dg_prime(
+        self,
+        reaction_id: str,
+        stoichiometry: Mapping[str, float],
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        p_mg: float = 14.0,
+        **kwargs: Any,
+    ) -> ReactionThermoEstimate:
+        """Estimate standard transformed Gibbs energy of a reaction.
+
+        Args:
+            reaction_id: Label for the result.
+            stoichiometry: compound id (namespaced) -> signed coefficient.
+            ph: Reaction pH.
+            ionic_strength: Ionic strength in M.
+            temperature: Temperature in K.
+            p_mg: pMg.
+            **kwargs: Ignored (accepted for interface compatibility).
+
+        Returns:
+            A :class:`ReactionThermoEstimate`. On a parse/estimate failure the
+            estimate carries ``dg_prime=None`` plus a warning rather than
+            raising (so the dispatcher can fall through to another backend).
+
+        Raises:
+            BackendUnavailableError: If the backend is not available.
+        """
+        cc = self._require()
+        estimate = ReactionThermoEstimate(
+            reaction_id=reaction_id,
+            backend=self.name,
+            ph=ph,
+            ionic_strength=ionic_strength,
+            temperature=temperature,
+            p_mg=p_mg,
+        )
+        formula = self._coeff_to_formula(stoichiometry)
+        estimate.equation = formula
+        try:
+            self._apply_conditions(cc, ph, ionic_strength, temperature, p_mg)
+            reaction = cc.parse_reaction_formula(formula)
+            if not reaction.is_balanced():
+                estimate.warnings.append(
+                    "Reaction is not atom-balanced according to eQuilibrator; "
+                    "ΔG'° may be unreliable."
+                )
+            dg = cc.standard_dg_prime(reaction)
+            # dg is a measurement with .value (a pint Quantity) and .error
+            estimate.dg_prime = float(dg.value.m_as("kJ/mol"))
+            estimate.dg_prime_uncertainty = float(dg.error.m_as("kJ/mol"))
+        except Exception as exc:
+            estimate.warnings.append(
+                f"equilibrator could not estimate ΔG'° ({type(exc).__name__}: {exc})"
+            )
+            self._log_warning(
+                f"equilibrator reaction estimate failed for {reaction_id}: {exc}"
+            )
+        return estimate
+
+    # ── compound ────────────────────────────────────────────────────────
+
+    def compound_dgf(
+        self,
+        compound_id: str,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        """Estimate a compound's standard transformed formation energy.
+
+        Args:
+            compound_id: Namespaced identifier (e.g. ``kegg:C00002``) or InChI.
+            ph: pH.
+            ionic_strength: Ionic strength in M.
+            temperature: Temperature in K.
+            **kwargs: Ignored (accepted for interface compatibility).
+
+        Returns:
+            A :class:`CompoundThermoEstimate`. On failure, ``dgf=None`` plus a
+            warning rather than raising.
+
+        Raises:
+            BackendUnavailableError: If the backend is not available.
+        """
+        cc = self._require()
+        estimate = CompoundThermoEstimate(
+            compound_id=compound_id,
+            backend=self.name,
+            ph=ph,
+            ionic_strength=ionic_strength,
+            temperature=temperature,
+        )
+        try:
+            self._apply_conditions(cc, ph, ionic_strength, temperature, 14.0)
+            compound = cc.get_compound(compound_id)
+            if compound is None:
+                estimate.warnings.append(
+                    f"equilibrator does not recognize compound '{compound_id}'"
+                )
+                return estimate
+            # standard_dg_formation returns (mu, sigmas_fin_or_None):
+            #   mu      -> standard formation energy in kJ/mol (float) or None
+            #   residual -> group-contribution residual vector (np.ndarray) or None
+            # Note: this is the *non*-transformed standard ΔGf at the reference
+            # state, not pH-transformed. We surface the central value; callers
+            # needing ΔG'f should derive it from reactions.
+            dgf, _residual = cc.standard_dg_formation(compound)
+            if dgf is not None:
+                estimate.dgf = float(dgf)
+                estimate.warnings.append(
+                    "equilibrator standard_dg_formation returns the untransformed "
+                    "standard ΔGf (not pH-transformed); treat with care."
+                )
+            else:
+                estimate.warnings.append(
+                    f"equilibrator has no formation energy for '{compound_id}'"
+                )
+        except Exception as exc:
+            estimate.warnings.append(
+                f"equilibrator could not estimate ΔGf'° "
+                f"({type(exc).__name__}: {exc})"
+            )
+            self._log_warning(
+                f"equilibrator compound estimate failed for {compound_id}: {exc}"
+            )
+        return estimate

--- a/src/kbutillib/thermo_predictors/modelseed_backend.py
+++ b/src/kbutillib/thermo_predictors/modelseed_backend.py
@@ -1,0 +1,190 @@
+"""ModelSEED-database backend (adapter over the existing ThermoUtils).
+
+This backend exposes the project's pre-existing ModelSEED deltaG lookups
+(:class:`kbutillib.thermo_utils.ThermoUtils`) through the common
+:class:`kbutillib.thermo_predictors.base.ThermoBackend` interface. It adds no
+new dependency and is always available wherever ``ThermoUtils`` works, so it
+serves as the dependable fallback in the dispatcher's priority order.
+
+It is a *lookup* backend, not a predictor: it returns values that exist in the
+ModelSEED database and reports ``missing_compounds`` (with no fabricated
+number) when they do not. Identifiers are ModelSEED accessions (``cpdNNNNN`` /
+``rxnNNNNN``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from .base import (
+    BackendUnavailableError,
+    CompoundThermoEstimate,
+    ReactionThermoEstimate,
+)
+
+
+class ModelSEEDBackend:
+    """Adapter exposing ModelSEED-DB deltaG lookups as a ThermoBackend.
+
+    Args:
+        thermo_utils: A :class:`kbutillib.thermo_utils.ThermoUtils` (or
+            ``ThermoUtilsImpl``) instance to delegate lookups to.
+        logger: Optional logger (duck-typed ``log_*`` / ``logging.Logger``).
+    """
+
+    name = "modelseed"
+
+    def __init__(self, thermo_utils: Any, logger: Any = None) -> None:
+        self._thermo = thermo_utils
+        self._logger = logger
+
+    def _log_warning(self, msg: str) -> None:
+        if self._logger is None:
+            return
+        warn = getattr(self._logger, "log_warning", None) or getattr(
+            self._logger, "warning", None
+        )
+        if callable(warn):
+            warn(msg)
+
+    @property
+    def available(self) -> bool:
+        """Available whenever a ThermoUtils delegate is present."""
+        return self._thermo is not None
+
+    @property
+    def unavailable_reason(self) -> Optional[str]:
+        """Reason string when unavailable, else ``None``."""
+        if self._thermo is None:
+            return "ModelSEED backend has no ThermoUtils delegate"
+        return None
+
+    @property
+    def capabilities(self) -> "frozenset[str]":
+        """Capabilities provided by ModelSEED lookups."""
+        return frozenset({"reaction_dg", "compound_dgf"})
+
+    def _require(self) -> Any:
+        if self._thermo is None:
+            raise BackendUnavailableError(
+                "ModelSEED backend has no ThermoUtils delegate"
+            )
+        return self._thermo
+
+    def reaction_dg_prime(
+        self,
+        reaction_id: str,
+        stoichiometry: Mapping[str, float],
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        p_mg: float = 14.0,
+        **kwargs: Any,
+    ) -> ReactionThermoEstimate:
+        """Look up a reaction's standard deltaG from the ModelSEED database.
+
+        Args:
+            reaction_id: ModelSEED reaction accession (e.g. ``rxn00001``). The
+                ``stoichiometry`` mapping is unused here because the ModelSEED
+                lookup resolves the reaction by its accession; it is accepted
+                for interface compatibility.
+            ph, ionic_strength, temperature, p_mg: Recorded on the result for
+                provenance. ModelSEED stored values are at standard conditions;
+                this backend does not re-transform them.
+            **kwargs: Passed through to ``calculate_reaction_deltag``
+                (e.g. ``use_compound_formation``, ``require_all_compounds``).
+
+        Returns:
+            A :class:`ReactionThermoEstimate`. On a lookup failure, ``dg_prime``
+            is ``None`` with an explanatory warning (no fabricated value).
+
+        Raises:
+            BackendUnavailableError: If no ThermoUtils delegate is present.
+        """
+        thermo = self._require()
+        estimate = ReactionThermoEstimate(
+            reaction_id=reaction_id,
+            backend=self.name,
+            ph=ph,
+            ionic_strength=ionic_strength,
+            temperature=temperature,
+            p_mg=p_mg,
+        )
+        try:
+            result = thermo.calculate_reaction_deltag(reaction_id, **kwargs)
+        except Exception as exc:
+            estimate.warnings.append(
+                f"ModelSEED reaction lookup failed ({type(exc).__name__}: {exc})"
+            )
+            self._log_warning(
+                f"ModelSEED reaction lookup failed for {reaction_id}: {exc}"
+            )
+            return estimate
+
+        if isinstance(result, dict):
+            dg = result.get("deltag")
+            estimate.dg_prime = float(dg) if dg is not None else None
+            err = result.get("deltag_error")
+            estimate.dg_prime_uncertainty = float(err) if err is not None else None
+            estimate.equation = result.get("equation")
+            for warning in result.get("warnings", []) or []:
+                estimate.warnings.append(str(warning))
+            for missing in result.get("missing_compounds", []) or []:
+                # missing entries may be dicts or strings depending on caller
+                if isinstance(missing, dict):
+                    cid = missing.get("compound_id") or missing.get("id") or str(missing)
+                else:
+                    cid = str(missing)
+                estimate.missing_compounds.append(cid)
+            estimate.raw = result
+        return estimate
+
+    def compound_dgf(
+        self,
+        compound_id: str,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        """Look up a compound's standard formation energy from ModelSEED.
+
+        Args:
+            compound_id: ModelSEED compound accession (e.g. ``cpd00002``).
+            ph, ionic_strength, temperature: Recorded on the result for
+                provenance.
+            **kwargs: Ignored (accepted for interface compatibility).
+
+        Returns:
+            A :class:`CompoundThermoEstimate`. ``dgf`` is ``None`` (with a
+            warning) if ModelSEED has no value (no fabricated number).
+
+        Raises:
+            BackendUnavailableError: If no ThermoUtils delegate is present.
+        """
+        thermo = self._require()
+        estimate = CompoundThermoEstimate(
+            compound_id=compound_id,
+            backend=self.name,
+            ph=ph,
+            ionic_strength=ionic_strength,
+            temperature=temperature,
+        )
+        try:
+            dgf = thermo.get_compound_deltag(compound_id)
+        except Exception as exc:
+            estimate.warnings.append(
+                f"ModelSEED compound lookup failed ({type(exc).__name__}: {exc})"
+            )
+            self._log_warning(
+                f"ModelSEED compound lookup failed for {compound_id}: {exc}"
+            )
+            return estimate
+
+        if dgf is None:
+            estimate.warnings.append(
+                f"ModelSEED has no formation energy for '{compound_id}'"
+            )
+        else:
+            estimate.dgf = float(dgf)
+        return estimate

--- a/src/kbutillib/thermo_predictors/modelseed_db_backend.py
+++ b/src/kbutillib/thermo_predictors/modelseed_db_backend.py
@@ -1,0 +1,320 @@
+"""ModelSEED-Database (Andrew Freiburger fork) baked-thermodynamics backend.
+
+Andrew expanded eQuilibrator coverage for the ModelSEED biochemistry universe
+by running stock eQuilibrator over a ModelSEED->MetaNetX structural mapping and
+**baking the resulting transformed standard Gibbs energies directly into the
+ModelSEED database TSVs** (``Biochemistry/compounds.tsv`` and
+``reactions.tsv``). Roughly 10,600 compounds and ~43,000 reactions carry an
+eQuilibrator-derived value, flagged ``EQU`` (compounds) / ``EQC``/``EQP``/
+``EQU`` (reactions) in their ``notes`` column.
+
+There is *no* custom thermodynamics library to call: "the expanded eQuilibrator
+within MSDB" means reading those precomputed columns. This backend therefore
+reads the TSVs directly with the standard library (no BiochemPy import, no
+``sys.path`` manipulation, no heavy dependency) and is the **preferred path
+when you are staying inside ModelSEED biochemistry** (it has broader coverage
+than a live stock-eQuilibrator call and needs no network/model download).
+
+Important caveats this backend is honest about
+----------------------------------------------
+* **Units.** The baked values are kcal/mol (Andrew converts from eQuilibrator's
+  native kJ/mol). This backend converts back to **kJ/mol** (factor 4.184) so it
+  matches the rest of :mod:`kbutillib.thermo_predictors`, which is kJ/mol
+  throughout.
+* **Transformed.** Values are standard transformed Gibbs energies (delta G'^0).
+* **Fixed conditions.** They were computed at pH 7.0, ionic strength 0.25 M,
+  298.15 K. They cannot be re-derived at other conditions. If a caller requests
+  different conditions, the backend returns the baked value *and adds a warning*
+  rather than silently pretending the value applies.
+* **Provenance preference.** By default it only returns a value flagged ``EQU``
+  (genuinely from the expanded eQuilibrator). A non-eQ Group-Contribution value
+  may also be present; set ``require_equilibrator=False`` to accept it, in which
+  case the provenance is reported in the warnings.
+
+Configuration
+-------------
+The backend needs the path to the fork's ``Biochemistry`` directory. It is
+resolved (in order) from: an explicit ``biochem_root`` constructor argument, the
+config key ``thermo.modelseed_db.biochem_root``, or the environment variable
+``MODELSEED_DATABASE_BIOCHEM_ROOT``. If none resolve to a readable
+``compounds.tsv``, the backend reports ``available == False`` and never
+fabricates a value.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from typing import Any, Dict, Mapping, Optional
+
+from .base import (
+    BackendUnavailableError,
+    CompoundThermoEstimate,
+    ReactionThermoEstimate,
+)
+
+#: kcal -> kJ.
+_KCAL_TO_KJ = 4.184
+
+#: Conditions the baked values were computed at (and only valid at).
+_BAKED_PH = 7.0
+_BAKED_IONIC_STRENGTH = 0.25
+_BAKED_TEMPERATURE = 298.15
+
+#: Config / environment keys for locating the database.
+CONFIG_BIOCHEM_ROOT = "thermo.modelseed_db.biochem_root"
+ENV_BIOCHEM_ROOT = "MODELSEED_DATABASE_BIOCHEM_ROOT"
+
+#: Sentinels ModelSEED writes for an absent value.
+_NULL_TOKENS = frozenset({"null", "none", "nan", "na", ""})
+
+#: notes tags that mark an eQuilibrator-derived value.
+_EQ_TAGS = frozenset({"EQU", "EQC", "EQP"})
+
+
+def _clean_root(root: str) -> str:
+    """Normalize to the directory that contains ``compounds.tsv``."""
+    root = os.path.expanduser(root)
+    # Accept either the Biochemistry dir or a path already pointing inside it.
+    if os.path.isfile(os.path.join(root, "compounds.tsv")):
+        return root
+    nested = os.path.join(root, "Biochemistry")
+    if os.path.isfile(os.path.join(nested, "compounds.tsv")):
+        return nested
+    return root
+
+
+def _parse_float(token: Optional[str]) -> Optional[float]:
+    """Parse a TSV cell to float, treating ModelSEED null sentinels as None."""
+    if token is None:
+        return None
+    if token.strip().lower() in _NULL_TOKENS:
+        return None
+    try:
+        return float(token)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_notes(token: Optional[str]) -> "frozenset[str]":
+    if not token or token.strip().lower() in _NULL_TOKENS:
+        return frozenset()
+    return frozenset(p.strip() for p in token.split("|") if p.strip())
+
+
+class ModelSEEDDBBackend:
+    """Reads baked transformed Gibbs energies from the ModelSEED Database fork.
+
+    Args:
+        biochem_root: Path to the fork's ``Biochemistry`` directory (or a parent
+            containing it). If omitted, resolved from config / environment.
+        config_resolver: Optional callable ``(key, default) -> value``.
+        require_equilibrator: When True (default) only values flagged with an
+            eQuilibrator tag (``EQU``/``EQC``/``EQP``) are returned; otherwise
+            any baked value is returned with its provenance in the warnings.
+        logger: Optional logger.
+    """
+
+    name = "modelseed_db"
+    capabilities = frozenset({"reaction_dg", "compound_dgf"})
+
+    def __init__(
+        self,
+        biochem_root: Optional[str] = None,
+        config_resolver: Any = None,
+        require_equilibrator: bool = True,
+        logger: Any = None,
+    ) -> None:
+        self._config = config_resolver
+        self._logger = logger
+        self._require_eq = require_equilibrator
+        self._root = self._resolve_root(biochem_root)
+        self._compounds: Optional[Dict[str, Dict[str, Any]]] = None
+        self._reactions: Optional[Dict[str, Dict[str, Any]]] = None
+        self._unavailable_reason: Optional[str] = None
+        if self._root is None or not os.path.isfile(
+            os.path.join(self._root, "compounds.tsv")
+        ):
+            self._unavailable_reason = (
+                "ModelSEED Database fork not found. Set a path to its "
+                f"Biochemistry directory via the `{CONFIG_BIOCHEM_ROOT}` config "
+                f"key or the `{ENV_BIOCHEM_ROOT}` environment variable. This "
+                "backend reads baked eQuilibrator deltaG values from "
+                "compounds.tsv / reactions.tsv (Andrew Freiburger's fork)."
+            )
+
+    # -- resolution / availability ------------------------------------------
+
+    def _resolve_root(self, explicit: Optional[str]) -> Optional[str]:
+        candidates = [explicit]
+        if self._config is not None:
+            try:
+                candidates.append(self._config(CONFIG_BIOCHEM_ROOT, None))
+            except Exception:  # pragma: no cover - resolver is best-effort
+                pass
+        candidates.append(os.environ.get(ENV_BIOCHEM_ROOT))
+        for cand in candidates:
+            if cand:
+                return _clean_root(str(cand))
+        return None
+
+    @property
+    def available(self) -> bool:
+        return self._unavailable_reason is None
+
+    @property
+    def unavailable_reason(self) -> Optional[str]:
+        return self._unavailable_reason
+
+    # -- lazy TSV loading ----------------------------------------------------
+
+    def _load_table(self, filename: str) -> Dict[str, Dict[str, Any]]:
+        assert self._root is not None  # guarded by `available` before any call
+        path = os.path.join(self._root, filename)
+        index: Dict[str, Dict[str, Any]] = {}
+        with open(path, newline="") as handle:
+            reader = csv.DictReader(handle, delimiter="\t")
+            for row in reader:
+                cid = (row.get("id") or "").strip()
+                if not cid:
+                    continue
+                index[cid] = {
+                    "deltag": _parse_float(row.get("deltag")),
+                    "deltagerr": _parse_float(row.get("deltagerr")),
+                    "notes": _parse_notes(row.get("notes")),
+                    "name": (row.get("name") or "").strip(),
+                    "equation": (row.get("equation") or "").strip(),
+                }
+        return index
+
+    @property
+    def _compound_index(self) -> Dict[str, Dict[str, Any]]:
+        if self._compounds is None:
+            self._compounds = self._load_table("compounds.tsv")
+        return self._compounds
+
+    @property
+    def _reaction_index(self) -> Dict[str, Dict[str, Any]]:
+        if self._reactions is None:
+            self._reactions = self._load_table("reactions.tsv")
+        return self._reactions
+
+    # -- helpers -------------------------------------------------------------
+
+    def _condition_warnings(
+        self, ph: float, ionic_strength: float, temperature: float
+    ) -> list:
+        warnings = []
+        if (
+            abs(ph - _BAKED_PH) > 1e-6
+            or abs(ionic_strength - _BAKED_IONIC_STRENGTH) > 1e-6
+            or abs(temperature - _BAKED_TEMPERATURE) > 1e-6
+        ):
+            warnings.append(
+                "ModelSEED Database values are precomputed at pH "
+                f"{_BAKED_PH}, I={_BAKED_IONIC_STRENGTH} M, "
+                f"T={_BAKED_TEMPERATURE} K and cannot be recomputed at the "
+                "requested conditions; returning the baked value as-is."
+            )
+        return warnings
+
+    def _provenance_ok(self, notes: "frozenset[str]", warnings: list) -> bool:
+        is_eq = bool(notes & _EQ_TAGS)
+        if self._require_eq and not is_eq:
+            return False
+        if not is_eq:
+            warnings.append(
+                "Value is not from the expanded eQuilibrator (no EQU/EQC/EQP "
+                f"tag); provenance notes={sorted(notes)}."
+            )
+        return True
+
+    # -- compute -------------------------------------------------------------
+
+    def compound_dgf(
+        self,
+        compound_id: str,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        if not self.available:
+            raise BackendUnavailableError(self._unavailable_reason)
+        warnings = self._condition_warnings(ph, ionic_strength, temperature)
+        entry = self._compound_index.get(compound_id)
+        if entry is None:
+            warnings.append(f"{compound_id} not in ModelSEED Database fork.")
+            return CompoundThermoEstimate(
+                compound_id=compound_id, backend=self.name, warnings=warnings,
+                ph=ph, ionic_strength=ionic_strength, temperature=temperature,
+            )
+        dgf_kcal = entry["deltag"]
+        if dgf_kcal is None or not self._provenance_ok(entry["notes"], warnings):
+            if dgf_kcal is None:
+                warnings.append(f"No baked deltaG for {compound_id}.")
+            return CompoundThermoEstimate(
+                compound_id=compound_id, backend=self.name, warnings=warnings,
+                ph=ph, ionic_strength=ionic_strength, temperature=temperature,
+            )
+        err_kcal = entry["deltagerr"]
+        return CompoundThermoEstimate(
+            compound_id=compound_id,
+            backend=self.name,
+            dgf=dgf_kcal * _KCAL_TO_KJ,
+            dgf_uncertainty=None if err_kcal is None else err_kcal * _KCAL_TO_KJ,
+            ph=_BAKED_PH,
+            ionic_strength=_BAKED_IONIC_STRENGTH,
+            temperature=_BAKED_TEMPERATURE,
+            warnings=warnings,
+            raw={"deltag_kcal": dgf_kcal, "notes": sorted(entry["notes"]),
+                 "name": entry["name"]},
+        )
+
+    def reaction_dg_prime(
+        self,
+        reaction_id: str,
+        stoichiometry: Mapping[str, float],
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        p_mg: float = 14.0,
+        **kwargs: Any,
+    ) -> ReactionThermoEstimate:
+        if not self.available:
+            raise BackendUnavailableError(self._unavailable_reason)
+        warnings = self._condition_warnings(ph, ionic_strength, temperature)
+        entry = self._reaction_index.get(reaction_id)
+        if entry is None:
+            warnings.append(f"{reaction_id} not in ModelSEED Database fork.")
+            return ReactionThermoEstimate(
+                reaction_id=reaction_id, backend=self.name, warnings=warnings,
+                ph=ph, ionic_strength=ionic_strength, temperature=temperature,
+                p_mg=p_mg,
+            )
+        dg_kcal = entry["deltag"]
+        if dg_kcal is None or not self._provenance_ok(entry["notes"], warnings):
+            if dg_kcal is None:
+                warnings.append(f"No baked deltaG for {reaction_id}.")
+            return ReactionThermoEstimate(
+                reaction_id=reaction_id, backend=self.name, warnings=warnings,
+                ph=ph, ionic_strength=ionic_strength, temperature=temperature,
+                p_mg=p_mg, equation=entry["equation"] or None,
+            )
+        err_kcal = entry["deltagerr"]
+        return ReactionThermoEstimate(
+            reaction_id=reaction_id,
+            backend=self.name,
+            dg_prime=dg_kcal * _KCAL_TO_KJ,
+            dg_prime_uncertainty=(
+                None if err_kcal is None else err_kcal * _KCAL_TO_KJ
+            ),
+            ph=_BAKED_PH,
+            ionic_strength=_BAKED_IONIC_STRENGTH,
+            temperature=_BAKED_TEMPERATURE,
+            p_mg=None,
+            equation=entry["equation"] or None,
+            warnings=warnings,
+            raw={"deltag_kcal": dg_kcal, "notes": sorted(entry["notes"]),
+                 "name": entry["name"]},
+        )

--- a/src/kbutillib/thermo_predictors/molgpk_backend.py
+++ b/src/kbutillib/thermo_predictors/molgpk_backend.py
@@ -1,0 +1,141 @@
+"""molGPK backend (stub — pending repository access from Andrew).
+
+molGPK predicts molecular pKa values and the predominant ionic microspecies of
+a compound at a given pH from chemical structure. Those microspecies are the
+inputs a rigorous transformed-thermodynamics calculation needs. Like
+dGPredictor it is research code with a custom install and a model artifact.
+
+Andrew Freiburger's variant lives at ``github.com/freiburgermsu/OPAM2`` (a
+previous intern named the project OPAM2; it is a fork of MolGpKa fine-tuned on
+the ModelSEED biochemistry database / MSDB). As of integration time that repo
+is private and not yet shared, so this backend stays a faithful interface stub
+that reports ``available == False``. It never fabricates pKa values or a
+microspecies assignment.
+
+Wiring it up later (drop-in, once OPAM2 access is granted)
+---------------------------------------------------------
+Source: ``github.com/freiburgermsu/OPAM2`` (MolGpKa fork, fine-tuned on MSDB).
+Andrew's note: "Andrew knows the method." MolGpKa upstream takes a molecule
+(SMILES/mol via RDKit) and returns per-atom acidic/basic pKa predictions from a
+graph-convolution model; OPAM2 fine-tunes that on MSDB compounds.
+
+1. ``_probe`` — replace with the real import + model-load (defer the heavy
+   RDKit/torch import; set ``self._model`` on success or
+   ``self._unavailable_reason`` on failure; never raise at import). Resolve the
+   repo + model artifact via the config keys below.
+2. ``compound_dgf`` — replace the ``BackendUnavailableError`` body with a call
+   into the model, populating ``pka_values``, ``major_microspecies`` and (if
+   the model provides it) a transformed ``dgf`` on the
+   :class:`CompoundThermoEstimate`. Confirm output UNITS and the microspecies
+   schema against OPAM2's README/tests before trusting any number.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from .base import (
+    BackendUnavailableError,
+    CompoundThermoEstimate,
+    ReactionThermoEstimate,
+)
+
+#: Config keys (dot-notation) consulted when this backend is wired up.
+CONFIG_REPO_PATH = "thermo.molgpk.repo_path"
+CONFIG_MODEL_PATH = "thermo.molgpk.model_path"
+CONFIG_PYTHON = "thermo.molgpk.python"
+
+_NOT_CONFIGURED = (
+    "molGPK backend is not configured. Andrew Freiburger's variant (OPAM2, a "
+    "MolGpKa fork fine-tuned on the MSDB) lives at github.com/freiburgermsu/OPAM2 "
+    "and is not yet accessible. Once access is granted, install the research code "
+    "+ model artifact, set `{repo}` and `{model}` in config, and complete _probe/"
+    "compound_dgf. Until then this backend reports unavailable and never "
+    "fabricates pKa or microspecies values."
+).format(repo=CONFIG_REPO_PATH, model=CONFIG_MODEL_PATH)
+
+
+class MolGPKBackend:
+    """molGPK pKa / microspecies predictor (interface stub).
+
+    Args:
+        config_resolver: Optional callable ``(key, default) -> value`` to read
+            configuration (e.g. ``SharedEnvUtils.get_config_value``).
+        logger: Optional logger (duck-typed ``log_*`` / ``logging.Logger``).
+    """
+
+    name = "molgpk"
+
+    def __init__(
+        self,
+        config_resolver: Any = None,
+        logger: Any = None,
+    ) -> None:
+        self._config = config_resolver
+        self._logger = logger
+        self._model: Any = None
+        self._unavailable_reason: Optional[str] = _NOT_CONFIGURED
+        self._probed = False
+
+    def _probe(self) -> None:
+        """Resolve availability. Currently always unavailable by design.
+
+        Replace this body when integrating: defer the real import, load the
+        model from the configured path, and on success set ``self._model`` and
+        clear ``self._unavailable_reason``.
+        """
+        if self._probed:
+            return
+        self._probed = True
+        self._unavailable_reason = _NOT_CONFIGURED
+
+    @property
+    def available(self) -> bool:
+        """Whether the backend can compute (False until integrated)."""
+        self._probe()
+        return self._model is not None
+
+    @property
+    def unavailable_reason(self) -> Optional[str]:
+        """Explanation of why the backend is unavailable."""
+        self._probe()
+        return self._unavailable_reason
+
+    @property
+    def capabilities(self) -> "frozenset[str]":
+        """Capabilities this backend will provide once integrated."""
+        return frozenset({"pka", "major_microspecies"})
+
+    def compound_dgf(
+        self,
+        compound_id: str,
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        **kwargs: Any,
+    ) -> CompoundThermoEstimate:
+        """Not implemented until integrated; never fabricates pKa/microspecies.
+
+        Raises:
+            BackendUnavailableError: Always, until the integration is completed.
+        """
+        raise BackendUnavailableError(self.unavailable_reason or _NOT_CONFIGURED)
+
+    def reaction_dg_prime(
+        self,
+        reaction_id: str,
+        stoichiometry: Mapping[str, float],
+        ph: float = 7.0,
+        ionic_strength: float = 0.25,
+        temperature: float = 298.15,
+        p_mg: float = 14.0,
+        **kwargs: Any,
+    ) -> ReactionThermoEstimate:
+        """molGPK targets compound pKa/microspecies, not reaction ΔG'°.
+
+        Raises:
+            BackendUnavailableError: Always (capability not provided).
+        """
+        raise BackendUnavailableError(
+            "molgpk does not provide reaction free energies"
+        )

--- a/src/kbutillib/toolkit.py
+++ b/src/kbutillib/toolkit.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from .argo_utils import ArgoUtilsImpl
     from .ai_curation_utils import AICurationUtilsImpl
     from .thermo_utils import ThermoUtilsImpl
+    from .predictive_thermo_utils import PredictiveThermoUtilsImpl
     from .mmseqs_utils import MMSeqsUtilsImpl
     from .skani_utils import SKANIUtilsImpl
     from .kb_berdl_utils import KBBERDLUtilsImpl
@@ -89,6 +90,7 @@ class KBUtilLib:
         self._argo = None
         self._curation = None
         self._thermo = None
+        self._predictive_thermo = None
         self._mmseqs = None
         self._skani = None
         self._berdl = None
@@ -218,6 +220,15 @@ class KBUtilLib:
             from .thermo_utils import ThermoUtilsImpl
             self._thermo = ThermoUtilsImpl(self.env, self.biochem)
         return self._thermo
+
+    @property
+    def predictive_thermo(self) -> "PredictiveThermoUtilsImpl":
+        """Predictive thermodynamics facade (equilibrator / dGPredictor /
+        molGPK / ModelSEED backends with graceful degradation)."""
+        if self._predictive_thermo is None:
+            from .predictive_thermo_utils import PredictiveThermoUtilsImpl
+            self._predictive_thermo = PredictiveThermoUtilsImpl(self.env, self.thermo)
+        return self._predictive_thermo
 
     @property
     def mmseqs(self) -> MMSeqsUtilsImpl:

--- a/tests/test_predictive_thermo.py
+++ b/tests/test_predictive_thermo.py
@@ -1,0 +1,430 @@
+"""Tests for the predictive-thermodynamics facade and its backends.
+
+These tests run without any optional scientific dependency installed. The
+equilibrator success path is exercised with an injected fake
+``ComponentContribution`` so no ~1 GB cache download is needed; the
+graceful-degradation path is exercised by *not* injecting one (the real
+``equilibrator_api`` import is expected to fail in CI).
+
+Core invariants under test:
+  * Importing the subpackage never requires an optional dependency.
+  * Backends never raise at construction when their dependency is absent.
+  * Backends never fabricate a value: unknown -> None + a warning.
+  * The dispatcher walks the priority order and falls through cleanly.
+  * The toolkit exposes the ``predictive_thermo`` lazy property.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from kbutillib.predictive_thermo_utils import (
+    PredictiveThermoUtils,
+    PredictiveThermoUtilsImpl,
+)
+from kbutillib.thermo_predictors import (
+    CompoundThermoEstimate,
+    DGPredictorBackend,
+    EquilibratorBackend,
+    ModelSEEDBackend,
+    ModelSEEDDBBackend,
+    MolGPKBackend,
+)
+from kbutillib.thermo_predictors.base import BackendUnavailableError
+
+# ── fakes ───────────────────────────────────────────────────────────────
+
+
+class _FakeThermoUtils:
+    """Minimal stand-in for ThermoUtils used by the ModelSEED backend."""
+
+    def __init__(self, compounds=None, reactions=None):
+        self._compounds = compounds or {}
+        self._reactions = reactions or {}
+
+    def get_compound_deltag(self, compound_id):
+        if compound_id not in self._compounds:
+            raise ValueError(f"Compound '{compound_id}' not found")
+        return self._compounds[compound_id]
+
+    def calculate_reaction_deltag(self, reaction_id, **kwargs):
+        if reaction_id not in self._reactions:
+            raise ValueError(f"Reaction '{reaction_id}' not found")
+        return self._reactions[reaction_id]
+
+
+class _FakeQuantity:
+    def __init__(self, value):
+        self._value = value
+
+    def m_as(self, _units):
+        return self._value
+
+
+class _FakeMeasurement:
+    def __init__(self, value, error):
+        self.value = _FakeQuantity(value)
+        self.error = _FakeQuantity(error)
+
+
+class _FakeReaction:
+    def __init__(self, balanced=True):
+        self._balanced = balanced
+
+    def is_balanced(self):
+        return self._balanced
+
+
+class _FakeComponentContribution:
+    """Just enough of eQuilibrator's API for the success path."""
+
+    def __init__(self, dg=-32.0, err=2.0, balanced=True):
+        self.p_h = None
+        self.ionic_strength = None
+        self.temperature = None
+        self.p_mg = None
+        self._dg = dg
+        self._err = err
+        self._balanced = balanced
+
+    def parse_reaction_formula(self, _formula):
+        return _FakeReaction(self._balanced)
+
+    def standard_dg_prime(self, _reaction):
+        return _FakeMeasurement(self._dg, self._err)
+
+    def get_compound(self, compound_id):
+        return SimpleNamespace(id=compound_id) if compound_id != "unknown:x" else None
+
+    def standard_dg_formation(self, _compound):
+        return (-2300.0, None)
+
+
+# Patch Q_ application: the fake CC has plain attributes, so _apply_conditions
+# must not blow up. equilibrator_api.Q_ is imported lazily inside the backend;
+# we monkeypatch it via a stub module so the success path works offline.
+@pytest.fixture
+def fake_equilibrator_module(monkeypatch):
+    import sys
+    import types
+
+    mod = types.ModuleType("equilibrator_api")
+    mod.Q_ = lambda *a, **k: SimpleNamespace(args=a)  # noqa: E731
+    mod.ComponentContribution = _FakeComponentContribution
+    monkeypatch.setitem(sys.modules, "equilibrator_api", mod)
+    return mod
+
+
+# ── import safety ───────────────────────────────────────────────────────
+
+
+def test_subpackage_imports_without_optional_deps():
+    import kbutillib.thermo_predictors as tp
+
+    assert hasattr(tp, "EquilibratorBackend")
+    assert hasattr(tp, "ModelSEEDBackend")
+
+
+# ── graceful degradation ────────────────────────────────────────────────
+
+
+def test_equilibrator_unavailable_does_not_raise_on_construction():
+    be = EquilibratorBackend()
+    # Without the package/cache, available is False and a reason is given.
+    if not be.available:
+        assert be.unavailable_reason
+        with pytest.raises(BackendUnavailableError):
+            be.reaction_dg_prime("r", {"kegg:C00002": -1, "kegg:C00008": 1})
+
+
+def test_dgpredictor_stub_is_unavailable_and_never_fabricates():
+    be = DGPredictorBackend()
+    assert be.available is False
+    assert "not configured" in (be.unavailable_reason or "")
+    with pytest.raises(BackendUnavailableError):
+        be.reaction_dg_prime("r", {"x": -1})
+
+
+def test_molgpk_stub_is_unavailable_and_never_fabricates():
+    be = MolGPKBackend()
+    assert be.available is False
+    assert "not configured" in (be.unavailable_reason or "")
+    with pytest.raises(BackendUnavailableError):
+        be.compound_dgf("cpd00001")
+
+
+# ── ModelSEED backend (lookup adapter) ──────────────────────────────────
+
+
+def test_modelseed_backend_compound_hit():
+    be = ModelSEEDBackend(_FakeThermoUtils(compounds={"cpd00002": -2300.0}))
+    assert be.available is True
+    est = be.compound_dgf("cpd00002")
+    assert est.dgf == -2300.0
+    assert est.backend == "modelseed"
+
+
+def test_modelseed_backend_compound_miss_returns_none_not_fabricated():
+    be = ModelSEEDBackend(_FakeThermoUtils(compounds={}))
+    est = be.compound_dgf("cpd99999")
+    assert est.dgf is None
+    assert est.warnings  # explains the miss
+
+
+def test_modelseed_backend_reaction_hit():
+    rxn = {
+        "deltag": -30.5,
+        "deltag_error": 1.2,
+        "equation": "A => B",
+        "warnings": [],
+        "missing_compounds": [],
+    }
+    be = ModelSEEDBackend(_FakeThermoUtils(reactions={"rxn00001": rxn}))
+    est = be.reaction_dg_prime("rxn00001", {})
+    assert est.dg_prime == -30.5
+    assert est.dg_prime_uncertainty == 1.2
+    assert est.equation == "A => B"
+
+
+def test_modelseed_backend_missing_delegate_raises():
+    be = ModelSEEDBackend(None)
+    assert be.available is False
+    with pytest.raises(BackendUnavailableError):
+        be.compound_dgf("cpd00001")
+
+
+# ── equilibrator success path (injected fake CC) ────────────────────────
+
+
+def test_equilibrator_reaction_success_with_injected_cc(fake_equilibrator_module):
+    be = EquilibratorBackend(component_contribution=_FakeComponentContribution(dg=-32.0, err=2.0))
+    est = be.reaction_dg_prime(
+        "atp_hydrolysis", {"kegg:C00002": -1, "kegg:C00001": -1, "kegg:C00008": 1, "kegg:C00009": 1}
+    )
+    assert est.dg_prime is not None
+    assert math.isclose(est.dg_prime, -32.0)
+    assert math.isclose(est.dg_prime_uncertainty, 2.0)
+    assert est.backend == "equilibrator"
+
+
+def test_equilibrator_unbalanced_warns(fake_equilibrator_module):
+    cc = _FakeComponentContribution(dg=-10.0, err=1.0, balanced=False)
+    be = EquilibratorBackend(component_contribution=cc)
+    est = be.reaction_dg_prime("r", {"kegg:C00002": -1, "kegg:C00008": 1})
+    assert any("not atom-balanced" in w for w in est.warnings)
+
+
+# ── dispatcher / facade ─────────────────────────────────────────────────
+
+
+def _facade(thermo_utils=None):
+    return PredictiveThermoUtils(
+        thermo_utils=thermo_utils,
+        config_file=False,
+        token_file=None,
+        kbase_token_file=None,
+    )
+
+
+class _UnavailableBackend:
+    """Stand-in backend that is always unavailable (deterministic dispatch).
+
+    Used so dispatch tests do not depend on whether the optional
+    equilibrator-api happens to be installed in the dev environment.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.capabilities = frozenset({"reaction_dg", "compound_dgf"})
+
+    @property
+    def available(self):
+        return False
+
+    @property
+    def unavailable_reason(self):
+        return f"{self.name} disabled for test"
+
+    def reaction_dg_prime(self, *a, **k):
+        raise BackendUnavailableError(self.unavailable_reason)
+
+    def compound_dgf(self, *a, **k):
+        raise BackendUnavailableError(self.unavailable_reason)
+
+
+def _facade_only_modelseed(thermo_utils):
+    """Facade with all backends above modelseed forced unavailable."""
+    facade = _facade(thermo_utils)
+    # Touch .backends to build the dict, then disable the upstream backends so
+    # the priority walk deterministically reaches modelseed.
+    facade.backends["equilibrator"] = _UnavailableBackend("equilibrator")
+    facade.backends["dgpredictor"] = _UnavailableBackend("dgpredictor")
+    facade.backends["modelseed_db"] = _UnavailableBackend("modelseed_db")
+    return facade
+
+
+def test_backend_status_reports_all_backends():
+    facade = _facade(_FakeThermoUtils())
+    status = facade.backend_status()
+    assert set(status) == {
+        "equilibrator",
+        "dgpredictor",
+        "modelseed_db",
+        "molgpk",
+        "modelseed",
+    }
+    assert status["modelseed"]["available"] is True
+    assert status["dgpredictor"]["available"] is False
+    assert status["molgpk"]["available"] is False
+
+
+def test_dispatch_falls_through_to_modelseed():
+    # equilibrator + dgpredictor unavailable -> modelseed answers.
+    facade = _facade_only_modelseed(_FakeThermoUtils(reactions={
+        "rxn00001": {"deltag": -30.0, "deltag_error": 1.0, "equation": "A=>B",
+                     "warnings": [], "missing_compounds": []},
+    }))
+    est = facade.reaction_dg_prime("rxn00001", {"cpd00002": -1})
+    assert est.dg_prime == -30.0
+    assert est.backend == "modelseed"
+    # provenance note recorded
+    assert any("modelseed" in w for w in est.warnings)
+
+
+def test_dispatch_no_backend_returns_honest_none():
+    facade = _facade_only_modelseed(_FakeThermoUtils(reactions={}))  # modelseed misses
+    est = facade.reaction_dg_prime("rxnZZZ", {"cpd00002": -1})
+    assert est.dg_prime is None
+    assert est.warnings  # lists what was attempted
+
+
+def test_explicit_backend_selection():
+    facade = _facade(_FakeThermoUtils(compounds={"cpd00002": -2300.0}))
+    est = facade.compound_dgf("cpd00002", backend="modelseed")
+    assert est.dgf == -2300.0
+    assert est.backend == "modelseed"
+
+
+def test_explicit_unknown_backend_raises():
+    facade = _facade(_FakeThermoUtils())
+    with pytest.raises(KeyError):
+        facade.get_backend("does-not-exist")
+
+
+def test_microspecies_routes_to_molgpk_and_degrades():
+    facade = _facade(_FakeThermoUtils())
+    est = facade.compound_microspecies("cpd00001")
+    assert isinstance(est, CompoundThermoEstimate)
+    assert est.pka_values == []
+    assert any("molgpk" in w for w in est.warnings)
+
+
+# ── toolkit registration ────────────────────────────────────────────────
+
+
+def test_toolkit_has_predictive_thermo_attribute_without_heavy_deps():
+    # The property must exist and be lazy: merely importing the toolkit and
+    # constructing it must not require modelseedpy (the chain is built only on
+    # first access of `predictive_thermo`).
+    from kbutillib.toolkit import KBUtilLib
+
+    assert isinstance(KBUtilLib.predictive_thermo, property)
+    kit = KBUtilLib(config_file=False, token_file=None, kbase_token_file=None)
+    assert kit._predictive_thermo is None  # not built yet
+
+
+def test_toolkit_exposes_predictive_thermo_property():
+    # The toolkit's predictive_thermo builds the `thermo` delegate, which in
+    # turn lazily constructs the ModelSEED biochem chain. That chain needs the
+    # heavy `modelseedpy` dependency (same convention as test_composition_smoke).
+    pytest.importorskip("modelseedpy", reason="modelseedpy required for biochem chain")
+    from kbutillib.toolkit import KBUtilLib
+
+    kit = KBUtilLib(config_file=False, token_file=None, kbase_token_file=None)
+    pt = kit.predictive_thermo
+    assert isinstance(pt, PredictiveThermoUtilsImpl)
+    # lazy: second access returns the same instance
+    assert kit.predictive_thermo is pt
+    # status query works through the Impl delegate
+    status = pt.backend_status()
+    assert "modelseed" in status
+
+
+# ── ModelSEEDDBBackend (baked eQuilibrator) ──────────────────────────────
+
+
+def _write_msdb_fixture(tmp_path):
+    """Write a minimal Biochemistry/ dir with two TSVs the backend reads."""
+    biochem = tmp_path / "Biochemistry"
+    biochem.mkdir()
+    compounds = biochem / "compounds.tsv"
+    compounds.write_text(
+        "id\tname\tdeltag\tdeltagerr\tnotes\n"
+        # EQU-tagged: -548.85 kcal/mol -> -2296.39 kJ/mol
+        "cpd00002\tATP\t-548.85\t0.36\tGC|EQ|EQU\n"
+        # value present but NOT eQuilibrator-tagged
+        "cpd99999\tFooGC\t-100.0\t1.0\tGC\n"
+        # no value
+        "cpd00000\tNoData\tnull\tnull\tGC\n"
+    )
+    reactions = biochem / "reactions.tsv"
+    reactions.write_text(
+        "id\tname\tdeltag\tdeltagerr\tnotes\n"
+        # -3.46 kcal/mol -> -14.476 kJ/mol
+        "rxn00001\tATPhydro\t-3.46\t0.05\tGCC|HB|EQC|EQU\n"
+    )
+    return str(biochem)
+
+
+def test_msdb_backend_compound_kcal_to_kj(tmp_path):
+    root = _write_msdb_fixture(tmp_path)
+    backend = ModelSEEDDBBackend(biochem_root=root)
+    assert backend.available is True
+    est = backend.compound_dgf("cpd00002")
+    assert est.dgf is not None
+    assert math.isclose(est.dgf, -548.85 * 4.184, rel_tol=1e-9)
+    assert math.isclose(est.dgf_uncertainty, 0.36 * 4.184, rel_tol=1e-9)
+    # fixed conditions reported
+    assert est.ph == 7.0
+    assert est.ionic_strength == 0.25
+    assert est.temperature == 298.15
+
+
+def test_msdb_backend_reaction_kcal_to_kj(tmp_path):
+    root = _write_msdb_fixture(tmp_path)
+    backend = ModelSEEDDBBackend(biochem_root=root)
+    est = backend.reaction_dg_prime("rxn00001", {"cpd00002": -1})
+    assert est.dg_prime is not None
+    assert math.isclose(est.dg_prime, -3.46 * 4.184, rel_tol=1e-9)
+
+
+def test_msdb_backend_unknown_compound_returns_none(tmp_path):
+    root = _write_msdb_fixture(tmp_path)
+    backend = ModelSEEDDBBackend(biochem_root=root)
+    est = backend.compound_dgf("cpd_missing")
+    assert est.dgf is None
+    assert est.warnings  # honest: explains why, never fabricates
+
+
+def test_msdb_backend_requires_equilibrator_tag_by_default(tmp_path):
+    root = _write_msdb_fixture(tmp_path)
+    backend = ModelSEEDDBBackend(biochem_root=root)
+    # value exists but is GC-only (no EQU/EQC/EQP) -> not returned by default
+    est = backend.compound_dgf("cpd99999")
+    assert est.dgf is None
+    # with the gate relaxed the value is returned, provenance in warnings
+    relaxed = ModelSEEDDBBackend(biochem_root=root, require_equilibrator=False)
+    est2 = relaxed.compound_dgf("cpd99999")
+    assert est2.dgf is not None
+    assert math.isclose(est2.dgf, -100.0 * 4.184, rel_tol=1e-9)
+
+
+def test_msdb_backend_unavailable_when_root_missing(tmp_path):
+    backend = ModelSEEDDBBackend(biochem_root=str(tmp_path / "nope"))
+    assert backend.available is False
+    assert backend.unavailable_reason
+    with pytest.raises(BackendUnavailableError):
+        backend.compound_dgf("cpd00002")


### PR DESCRIPTION
## Summary

Adds a `PredictiveThermoUtils` facade that estimates standard transformed Gibbs energies of **formation** (compounds) and **reaction** (Δ_r G'°) by dispatching across a priority-ordered set of pluggable backends. Every backend degrades gracefully and **never fabricates a value** — unknown inputs return `None` plus a warning, so callers always know provenance.

Exposed as the lazy `predictive_thermo` property on `KBUtilLib`.

## Backends (`src/kbutillib/thermo_predictors/`)

| backend | source | notes |
|---|---|---|
| `equilibrator` | live component-contribution (`equilibrator-api`, optional dep) | condition-aware: pH, ionic strength, T, p_Mg |
| `dgpredictor` | Maranas/Tyo group-contribution reaction predictor (Freiburger fork) | runs **out-of-process** against a local clone to keep rdkit/openbabel + the ~150 MB model out of this process; KEGG stoichiometry in, kJ/mol Δ_r G'° out; detects a missing / Git-LFS-pointer model and reports unavailable |
| `modelseed_db` | baked transformed ΔG from the expanded-eQuilibrator ModelSEED Database fork | reads `compounds.tsv`/`reactions.tsv` directly with the **stdlib csv** reader; kcal→kJ; fixed pH 7 / I 0.25 M / 298.15 K; EQU/EQC/EQP provenance gate |
| `modelseed` | existing `ThermoUtils` ModelSEED lookups | always-on fallback, no new dependency |
| `molgpk` | Tyo-lab molGPK / OPAM2 (unreleased) | stub; reports unavailable until configured |

**Dispatch order:** `equilibrator → dgpredictor → modelseed_db → modelseed`.

## Design invariants

- Nothing in the subpackage imports a heavy/optional dependency at module-import time; all such imports are deferred into the backend that needs them.
- Backends never raise at construction when a dependency is absent.
- No-fabrication: unknown → `None` + warning, never a stand-in value.
- Heavy/fragile research code (dGPredictor) is isolated behind a subprocess worker, configured via `thermo.dgpredictor.repo_path` / `DGPREDICTOR_REPO` (and `thermo.dgpredictor.python`); `modelseed_db` via `thermo.modelseed_db.biochem_root` / `MODELSEED_DATABASE_BIOCHEM_ROOT`.

## Packaging & tests

- Adds `[project.optional-dependencies]` `equilibrator` / `thermo` extras (core install unchanged).
- New **dependency-free** suite `tests/test_predictive_thermo.py` (22 passing, 1 skipped): graceful degradation, the no-fabrication invariant, dispatch fall-through, backend-status reporting, and kcal→kJ conversion against worked **ATP** / **rxn00001** values.

## Live validation (local)

- equilibrator ATP+H2O→ADP+Pi: **-30.11 ± 0.30 kJ/mol** @ pH7/I0.25/298.15 K
- dgpredictor same reaction: **-26.14 ± 3.29 kJ/mol** (agrees within model uncertainty)
- modelseed_db ATP cpd00002: **-2296.39 kJ/mol** (-548.85 kcal × 4.184); rxn00001: **-14.48 kJ/mol**

`ruff` clean on all touched files.