### PR TITLE
fix(pickaxe): add missing MINE-Database configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -77,3 +77,8 @@ remote_solver:
   threads_per_solve: null  # service: null -> floor(cpu_count / max_concurrent_solves)
   default_time_limit: 3600  # service: applied when a solve omits time_limit
   max_time_limit: 7200  # service: ceiling caller time_limit values are clamped to
+
+# Highest-priority MINE-Database reaction-rule TSV location; empty falls back to $KBUTILLIB_PICKAXE_DATA_DIR, installed minedatabase data, or the MINE-Database checkout in dependencies.yaml.
+cheminformatics:
+  pickaxe:
+    data_dir: ""

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -30,3 +30,7 @@ dependencies:
   cb_annotation_ontology_api:
     path: "../cb_annotation_ontology_api"
     git: "https://github.com/kbaseapps/cb_annotation_ontology_api.git"
+
+  MINE-Database:
+    path: "../MINE-Database"
+    git: "https://github.com/tyo-nu/MINE-Database.git"


### PR DESCRIPTION
Follow-up to #48 after the reorg landed on main.

Adds the missing `MINE-Database` dependency declaration and `cheminformatics.pickaxe.data_dir` configuration used by the existing Pickaxe backend. Preserves the existing `remote_solver` configuration and packaging dependencies.

This is intentionally a fresh branch from current `main`, not a rebase of #48.

Related: #48
Commit: 2db23e8